### PR TITLE
Omit HTMLescaped-markup from PubMed titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Sertroid is a small, simple set of scripts which queries the [Tripsit](https://t
 
 It then takes these drug names and searches for scientific papers which have been cited on the [Pubmed database](https://www.ncbi.nlm.nih.gov/pubmed/) that day which contain those drug names, and obtains some relevant summary data and urls for those papers using the [Entrez E-utilities service](https://www.ncbi.nlm.nih.gov/books/NBK25497/).
 
-It then outputs this information into an [channel](https://chat.tripsit.me/chat/?a=1&theme=dark&##paperflood) on the Tripsit IRC network. Sertroid runs on Tripsit once per 24hrs at 00:00 UTC.
+It then outputs this information into a [channel](https://chat.tripsit.me/chat/?a=1&theme=dark&##paperflood) on the Tripsit IRC network. Sertroid runs on Tripsit once per 24hrs.
 
 The purpose of this program is to make it very easy for users of the network to keep up to date with the latest science on psychoactive substances of all kinds.
 

--- a/api_query.py
+++ b/api_query.py
@@ -22,7 +22,7 @@ data = []
 
 for value in response:      #remove none values
     if value is not None:
-        data.append(value) 
+        data.append(value)
 
 big_list = [] # big chonk
 
@@ -32,7 +32,7 @@ for value in data:
 
         # sets entrez url to a drug from the druglist
         entrez_url="https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&reldate=1&retmax=1000&retmode=json&term=" + value
-        
+
         entrez_response = requests.get(entrez_url) #returns json data
 
         parsed_json = entrez_response.json() # parses json data into python list
@@ -40,23 +40,23 @@ for value in data:
         key = "esearchresult"
 
         drugname = value
-          
+
         if key in parsed_json: # sometimes the json doesn't have the key we want for no reason  ¯\_(ツ)_/¯, this checks if it exists
 
             list_of_pmids = parsed_json["esearchresult"]["idlist"] # retrieves list of pmids from python list
-            
+
             drugdict = collections.OrderedDict()
 
             for item in list_of_pmids:
 
-                drugdict[item] = drugname 
-        
+                drugdict[item] = drugname
+
         else:
             pass
-        
+
         big_list.append(drugdict) # joins all pmids into one big list
 
-        
+
 
         time.sleep(0.334) # to avoid getting b& from pubmed for spamming them with requests (pubmed allows 3 url requests per second)
 
@@ -66,7 +66,7 @@ for value in data:
 flat_dictionary = {}
 
 print(flat_dictionary)
-    
+
 for dictionary in big_list:  #flattening list
     flat_dictionary.update(dictionary)
 
@@ -100,7 +100,7 @@ for key, item in flat_dictionary.items():
         matched_article_id = None
 
         for article_id in article_ids:
-    
+
             if article_id['idtype'] == "doi":
 
                 matched_article_id = article_id
@@ -108,15 +108,9 @@ for key, item in flat_dictionary.items():
                 doi = "https://doi.org/" + matched_article_id['value']
 
 
-        
+
         # Prints paper title, PMID and pubmed URL in a human-readable form
         print("[Pubmed] " + "[{}] ".format(drugname) + title + " URL: " + pubmed_url  + " DOI: " + doi)
 
-    else: 
+    else:
         pass
-
-
-
-
-
-

--- a/irc_relay.py
+++ b/irc_relay.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 import socket
 import time
-import threading 
+import threading
 import sys
 import os
 
@@ -10,7 +10,7 @@ server = "irc.tripsit.me"
 nick = "sertroid"
 channel ="##paperflood"
 
-irc = socket.socket(socket.AF_INET, socket.SOCK_STREAM) 
+irc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
 print("irc_relay.py now running")
 
@@ -36,7 +36,7 @@ def irc_text():
     while True:
         text = irc.recv(2040)
         text = text.decode("UTF-8")
-        
+
 
         if text.find("PING") != -1:
             irc.send(bytes("PONG \n", "utf-8"))
@@ -45,12 +45,12 @@ def irc_text():
 def output():
     with open('/home/user/sertroid/pubmed_output.txt') as f:
             for line in f:
-            
+
                 irc.send(bytes("PRIVMSG "+ channel +" :" + line, "utf-8"))
                 time.sleep(1)
 
             print("Flood complete, exiting")
-            os._exit(0)        
+            os._exit(0)
 
 def main():
 


### PR DESCRIPTION
This PR is submitted in the name of human-readability of the bot's text output; note that it silently, yet unmaliciously, depends upon a cleanup commit; and conflicts with the PR which only fixes the IRC messages, leaving the garbage markup in the bot's internal data.

Closes #1 
Closes #2 